### PR TITLE
Update get_platform in install.sh for Apple Silicon

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,6 +16,7 @@ get_platform() {
     i686) architecture="386" ;;
     x86_64) architecture="amd64" ;;
     arm) dpkg --print-architecture | grep -q "arm64" && architecture="arm64" || architecture="arm" ;;
+    arm64) architecture="arm64" ;;
     *) exit 1
     esac
 }


### PR DESCRIPTION
Apple Silicon reports `arm64` when running `uname -m`. This is a valid release architecture, but the `case` statement has no entry for it, so it falls through to the `exit 1` line. This adds the needed entry. I've verified that install succeeds with this added.