### PR TITLE
Fixed quotes bug in FORM/MULTIPART

### DIFF
--- a/cmdgen/cmdgen.go
+++ b/cmdgen/cmdgen.go
@@ -70,7 +70,8 @@ func assembleCmdString(httpv string, url string, jsonObj *gabs.Container, header
 
 	if multipart {
 		for key, val := range jsonObj.Data().(*gabs.Container).ChildrenMap() {
-			command = append(command, key+"="+val.Data().(string))
+			keyValuePair := fmt.Sprintf("%s=%s", key, val.Data().(string))
+			command = append(command, keyValuePair)
 		}
 		for key, val := range files.ChildrenMap() {
 			command = append(command, key+"@"+val.Data().(string))
@@ -79,7 +80,7 @@ func assembleCmdString(httpv string, url string, jsonObj *gabs.Container, header
 
 	if form {
 		for key, val := range jsonObj.Data().(*gabs.Container).ChildrenMap() {
-			keyValuePair := fmt.Sprintf("'%s'='%s'  ", key, val.Data().(string))
+			keyValuePair := fmt.Sprintf("%s=%s", key, val.Data().(string))
 			command = append(command, keyValuePair)
 		}
 	}

--- a/cmdgen/cmdgen.go
+++ b/cmdgen/cmdgen.go
@@ -70,7 +70,7 @@ func assembleCmdString(httpv string, url string, jsonObj *gabs.Container, header
 
 	if multipart {
 		for key, val := range jsonObj.Data().(*gabs.Container).ChildrenMap() {
-			command = append(command, "'"+key+"'='"+val.Data().(string)+"'  ")
+			command = append(command, key+"="+val.Data().(string))
 		}
 		for key, val := range files.ChildrenMap() {
 			command = append(command, key+"@"+val.Data().(string))

--- a/tests/form_test.go
+++ b/tests/form_test.go
@@ -18,7 +18,7 @@ func TestFormPositive(t *testing.T) {
 		return
 	}
 
-	expectedOutputPart := "\"form\": {\n    \"'first'\": \"'second'\", \n    \"'third'\": \"'fourth'\"\n  }"
+	expectedOutputPart := "\"form\": {\n    \"first\": \"second\", \n    \"third\": \"fourth\"\n  }"
 	if !strings.Contains(output, expectedOutputPart) {
 		t.Errorf("Expected output to contain %q, but got %q", expectedOutputPart, output)
 	}
@@ -45,7 +45,7 @@ func TestMultipartPositive(t *testing.T) { // File not attached to Multipart, wh
 		return
 	}
 
-	expectedOutputPart := "\"form\": {\n    \"'first'\": \"'second'\", \n    \"'third'\": \"'fourth'\"\n  }"
+	expectedOutputPart := "\"form\": {\n    \"first\": \"second\", \n    \"third\": \"fourth\"\n  }"
 	if !strings.Contains(output, expectedOutputPart) {
 		t.Errorf("Expected output to contain %q, but got %q", expectedOutputPart, output)
 	}

--- a/tests/formtests/test_form_negative.l2
+++ b/tests/formtests/test_form_negative.l2
@@ -2,8 +2,8 @@ POST
 FORM
 http://httpbin.org/post
 # DATA
-first='second'
-third='fourth'
+first=second
+third=fourth
 
 # FILES
 

--- a/tests/formtests/test_form_positive.l2
+++ b/tests/formtests/test_form_positive.l2
@@ -2,5 +2,5 @@ POST
 FORM
 http://httpbin.org/post
 # DATA
-first='second'
-third='fourth'
+first=second
+third=fourth

--- a/tests/formtests/test_multipart_positive.l2
+++ b/tests/formtests/test_multipart_positive.l2
@@ -2,5 +2,5 @@ POST
 MULTIPART
 http://httpbin.org/post
 # DATA
-first='second'
-third='fourth'
+first=second
+third=fourth


### PR DESCRIPTION
<!--
  Before submitting a Merge Request, please ensure you've done the following:
  - 👷‍♀️ Create small MRs. In most cases, this will be possible.
  - 📝 Use descriptive commit messages.
-->

## What type of MR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Doc Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Description

<!--
Please do not leave this blank
This MR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

This MR fixes a quotes bug for FORM/Multipart, where there are extra quotes in the response
![image](https://github.com/HexmosTech/Lama2/assets/95300799/74445bf2-ec76-42e7-bae5-062c5884de43)


## Important files to start review from
- cmdgen.go

## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation? 
## If documentation update is there then run `make mkdocs` once PR is in acceptable state.

- [ ] 📓 make mkdocs
- [ ] 📜 README.md
- [x] 🙅 no documentation needed
